### PR TITLE
adiciona metodo que cria tarefa no Monday quando um Pull Request é aberto

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,49 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const axios = require('axios');
-
 const app = express();
 app.use(bodyParser.json());
-const PORT = process.env.PORT || 3000; // Define a porta do servidor
+const PORT = process.env.PORT || 3000;
+
+const { MONDAY_BOARD_ID, MONDAY_AUTH_TOKEN } = require('./config');
+
+// Função para criar uma tarefa no Monday.com para revisão do Pull Request aberto no GitHub
+async function createTaskMondayReviewPullRequest(eventData) {
+  const repository = eventData.repository.full_name;
+  const number = eventData.number;
+
+  let query = 'mutation{ create_item (board_id:' + MONDAY_BOARD_ID + ', item_name:"Revisar Pull Request - ' + repository + '#' + number + '") { id } }';
+
+  try {
+    const response = await axios.post("https://api.monday.com/v2", { query: query }, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': MONDAY_AUTH_TOKEN // Token criado no Monday
+      }
+    });
+
+    console.log(JSON.stringify(response.data, null, 2));
+    return true;
+  } catch (error) {
+    console.error('Erro ao criar a tarefa no Monday.com:', error);
+    return false;
+  }
+}
 
 // Rota para receber o webhook do GitHub
-app.post('/github-webhook', (req, res) => {
+app.post('/github-webhook-pull-request', async (req, res) => {
   const eventData = req.body;
 
-  if (eventData.action === 'started' && eventData.repository) {
-    // Implemente a criação da tarefa no Monday.com aqui
-    console.log('Repositório marcado como favorito:', eventData.repository.full_name);
+  if (eventData.action === 'opened' && eventData.repository) {
+    try {
+      const mondayResponse = await createTaskMondayReviewPullRequest(eventData);
+
+      if (mondayResponse) {
+        console.log('Tarefa criada no Monday.com');
+      }
+    } catch (error) {
+      console.error('Erro ao conectar com o Monday.com:', error.message);
+    }
   }
 
   res.sendStatus(200);


### PR DESCRIPTION
**Descrição:**

Este pull request implementa uma solução que lida com 'webhooks' do GitHub quando uma nova pull request é criada. O objetivo é automatizar a criação de uma tarefa no sistema de gerenciamento de projetos 'Monday.com', facilitando o processo de revisão de pull requests.

**Funcionamento:**
Quando uma pull request é aberta no repositório configurado (README), o sistema irá acionar um 'webhook' que ativará a função `createTaskMondayReviewPullRequest` no código. Esta função, por sua vez, usará a API do Monday.com para criar uma nova tarefa no quadro especificado. O título da tarefa será "Revisar Pull Request - {nome do repositório} #{número da pull request}", o que facilitará a identificação da tarefa.

A implementação é projetada para ser escalável e de fácil manutenção. Os detalhes de configuração, como o ID do quadro do Monday.com e as credenciais de autorização, foram isolados no arquivo `config.js` que não é versionado, garantindo a segurança dessas informações sensíveis.

Esta solução visa aumentar a eficiência do processo de revisão de pull requests e melhorar a visibilidade das tarefas pendentes de revisão. 

Observação: Certifique-se de configurar corretamente as variáveis no arquivo `config.js` para que o sistema possa funcionar sem problemas (README).
